### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/player.py
+++ b/player.py
@@ -136,10 +136,10 @@ class Player:
 		m, s = divmod(s, 60)
 
 		if m < 60:
-			return "%02i:%02i" % (m, s)
+			return "{0:02d}:{1:02d}".format(m, s)
 		else:
 			h, m = divmod(m, 60)
-			return "%i:%02i:%02i" % (h, m, s)
+			return "{0:d}:{1:02d}:{2:02d}".format(h, m, s)
 
 	def time_update(self):
 		"""Updates the showed time in the slider and label"""


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:nils-van-zuijlen:sound-organiser-offline-app?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:nils-van-zuijlen:sound-organiser-offline-app?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)